### PR TITLE
add use_renderer option

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -4,13 +4,13 @@ use Test::More;
 use Email::MIME::Kit;
 use Email::MIME::Kit::Assembler::Markdown;
 
-for my $suffix ('', '-munge') {
+for my $suffix ('', '-munge', '-renderer') {
   my $path = "t/kit/sample$suffix.mkit";
 
   subtest $path => sub {
     my $kit = Email::MIME::Kit->new({ source => $path });
 
-    my $email = $kit->assemble;
+    my $email = $kit->assemble({ mail_type => 'electrical', endorsement_type => 'PAID' });
 
     my @parts = $email->subparts;
 

--- a/t/kit/sample-renderer.mkit/body.mkdn
+++ b/t/kit/sample-renderer.mkit/body.mkdn
@@ -1,0 +1,15 @@
+
+## Fantastic New Assembler!
+
+The new *Markdown* Assembler provides:
+
+* awesome features
+* **colossal** hacks
+* a great demonstration of the need to refactor the std assembler
+* a guy reading _Finnegan's Wake_
+
+Please enjoy!
+
+-- 
+Yours truly,
+Ricardo Signes

--- a/t/kit/sample-renderer.mkit/manifest.json
+++ b/t/kit/sample-renderer.mkit/manifest.json
@@ -1,0 +1,16 @@
+{
+  "renderer" : "TestRenderer",
+  "path" : "body.mkdn",
+  "assembler" : [
+    "Markdown",
+    {
+      "html_wrapper" : "wrapper.html",
+      "text_wrapper" : "wrapper.txt",
+      "use_renderer" : true
+    }
+  ],
+  "header" : [
+    { "Subject" : "this is a markdown test" },
+    { "From" : "\"Ricardo Signes\" <rjbs@example.com>" }
+  ]
+}

--- a/t/kit/sample-renderer.mkit/wrapper.html
+++ b/t/kit/sample-renderer.mkit/wrapper.html
@@ -1,0 +1,4 @@
+<div>
+<h1>This [% mail_type %] mail message transmitted via EtherNet™</h1>
+[% wrapped_content %]
+</div>

--- a/t/kit/sample-renderer.mkit/wrapper.txt
+++ b/t/kit/sample-renderer.mkit/wrapper.txt
@@ -1,0 +1,5 @@
+THE FOLLOWING IS NOT A [% endorsement_type %] ENDORSEMENT
+
+[% wrapped_content %]
+
+THANK YOU FOR READING OUR [% endorsement_type %] ENDORSEMENT


### PR DESCRIPTION
As discussed (iirc anyway).

Set `use_renderer` to a true value. Now your wrappers are templates, and you get the Markdown-processed content in the `wrapped_content` template parameter instead of it replacing a comment. 
